### PR TITLE
 Adding Design doc link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                         <li><a href="https://pinot.readthedocs.io/en/latest/architecture.html" target="_blank">Architecture <i class="fa fa-external-link"></i></a></li>
                         <li class="divider"></li>
                         <li><a href="https://cwiki.apache.org/confluence/display/PINOT" target="_blank">Wiki <i class="fa fa-external-link"></i></a></li>
+                        <li><a href="https://cwiki.apache.org/confluence/display/PINOT/Design+Documents" target="_blank">Design Documents <i class="fa fa-external-link"></i></a></li>
                         <li><a href="https://cwiki.apache.org/confluence/display/PINOT/Blogs+and+Talks" target="_blank">Blogs and Talks <i class="fa fa-external-link"></i></a></li>
                     </ul>
                 </li>


### PR DESCRIPTION
This PR adds a link to the design docs on cwiki