### PR TITLE
Fix for `Trademarks` check in the ASF site.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -188,7 +188,7 @@ module.exports = {
         src: 'img/logo.svg',
         href: 'https://pinot.apache.org/',
       },
-      copyright: `Disclaimer: Apache Pinot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.<br><br>Copyright © ${new Date().getFullYear()} Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.`,
+      copyright: `Disclaimer: Apache Pinot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.<br><br>Copyright © ${new Date().getFullYear()} Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are registered trademarks of The Apache Software Foundation.`,
     },
     googleAnalytics: {
       trackingID: 'UA-157446650-1',


### PR DESCRIPTION
Re-phrased copyright text to match the regular expression as expected by ASF web-site check.
Although, the original text was taken from the ASF website, apparently it seems to fail.
Trying out a text used by other projects where the test passes.