### PR TITLE
Try 2: Fixing Trademark checks on ASF.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -188,7 +188,7 @@ module.exports = {
         src: 'img/logo.svg',
         href: 'https://pinot.apache.org/',
       },
-      copyright: `Disclaimer: Apache Pinot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.<br><br>Copyright © ${new Date().getFullYear()} Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are registered trademarks of The Apache Software Foundation.`,
+      copyright: `Disclaimer: Apache Pinot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.<br><br>Copyright © ${new Date().getFullYear()} The Apache Software Foundation.<br>Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are registered trademarks of The Apache Software Foundation.`,
     },
     googleAnalytics: {
       trackingID: 'UA-157446650-1',


### PR DESCRIPTION
Apparently, the "Copyright © 2020 The Apache Software Foundation" should be a separate line
from the line that contains the trademark keyword.