### PR TITLE
Fix footer to say `Integrations` instead of `Components`.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -105,7 +105,7 @@ module.exports = {
           ],
         },
         {
-          title: 'Components',
+          title: 'Integrations',
           items: [
             {
               label: 'Presto',


### PR DESCRIPTION
The section that listed Presto/TE was titled `Components`.
Fixed it to say `Integrations` instead.