### PR TITLE
Fix download urls for prior releases.

### DIFF
--- a/website/src/pages/download.js
+++ b/website/src/pages/download.js
@@ -78,7 +78,7 @@ function Download() {
 
                                     <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
                                     <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz.sha512">
@@ -95,7 +95,7 @@ function Download() {
                             </div>
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -104,33 +104,33 @@ function Download() {
 
                                     <div className="panel--title">0.6.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.6.0/apache-pinot-incubating-0.6.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>
@@ -139,7 +139,7 @@ function Download() {
                             </div>
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -148,33 +148,33 @@ function Download() {
 
                                     <div className="panel--title">0.5.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.5.0/apache-pinot-incubating-0.5.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>
@@ -183,7 +183,7 @@ function Download() {
                             </div>
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -192,33 +192,33 @@ function Download() {
 
                                     <div className="panel--title">0.4.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.4.0/apache-pinot-incubating-0.4.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>
@@ -228,7 +228,7 @@ function Download() {
 
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -237,33 +237,33 @@ function Download() {
 
                                     <div className="panel--title">0.3.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.3.0/apache-pinot-incubating-0.3.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>
@@ -273,7 +273,7 @@ function Download() {
 
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -282,33 +282,33 @@ function Download() {
 
                                     <div className="panel--title">0.2.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.2.0/apache-pinot-incubating-0.2.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>
@@ -318,7 +318,7 @@ function Download() {
 
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz"
+                                    href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -327,33 +327,33 @@ function Download() {
 
                                     <div className="panel--title">0.1.0</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz">
                                         <div className="panel--title">
-                                            Official binary release
+                                            Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz.sha512">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz.asc">
+                                    <a href="https://archive.apache.org/dist/incubator/pinot/apache-pinot-incubating-0.1.0/apache-pinot-incubating-0.1.0-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>


### PR DESCRIPTION
Prior releases are auto archived, fixed their urls to point to
archive.apache.org.

Also, renamed `Official Binary Release` to `Binary download`.