### PR TITLE
Update pinot docs to remove incubator reference

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -56,7 +56,7 @@ Example:  `website/blog/2017-09-17-Restaurant-Manager.md`
 
 Then fill in all the sections titles, author, etc..
 
-Example: https://raw.githubusercontent.com/apache/incubator-pinot-site/ff73eceb6fa5f8128d9332bf95f92eab2d9c5b6a/website/blog/2017-09-17-Restaurant-Manager.md
+Example: https://raw.githubusercontent.com/apache/pinot-site/ff73eceb6fa5f8128d9332bf95f92eab2d9c5b6a/website/blog/2017-09-17-Restaurant-Manager.md
 
 ## Adding new Companies
 

--- a/website/docs/about/what_is_pinot.md
+++ b/website/docs/about/what_is_pinot.md
@@ -17,7 +17,7 @@ Pinot is designed to answer OLAP queries with low latency. It is suited in conte
 
 Pinot is not a replacement for your database, nor a search engine. It addresses fast analytics on immutable data and it is not thought by design, to handle data updates or deletions. Joins are currently not supported, but this problem can be overcome by using [PrestoDB]((https://prestodb.io/)) for querying Pinot.
 
-For more information about PrestoDB connector for Pinot see the [Helm Chart of Pinot with Presto](https://github.com/apache/incubator-pinot/tree/master/kubernetes/examples/helm#access-pinot-using-presto)
+For more information about PrestoDB connector for Pinot see the [Helm Chart of Pinot with Presto](https://github.com/apache/pinot/tree/master/kubernetes/examples/helm#access-pinot-using-presto)
 Pinot-Presto connector is avilable with version [0.229](https://github.com/prestodb/presto/pull/13504)
 
 ## Quick example

--- a/website/docs/about/who_use_pinot.md
+++ b/website/docs/about/who_use_pinot.md
@@ -9,11 +9,11 @@ draft: true
 
 | Company        | Notes           |
 | ------------- |:-------------:|
-| LinkedIn      | LinkedIn uses Pinot for delivering fast analytics. |
-| Uber      | Uber uses Apache Pinot (incubating)      |
-| Microsoft | Microsoft uses Apache Pinot (incubating)      |
-| Weibo     | Weibo uses Apache Pinot (incubating)              |
-| Factual   | Factual uses Apache Pinot (incubating)              |
+| LinkedIn      | LinkedIn uses Pinot for delivering fast analytics |
+| Uber      | Uber uses Apache Pinot |
+| Microsoft | Microsoft uses Apache Pinot |
+| Weibo     | Weibo uses Apache Pinot |
+| Factual   | Factual uses Apache Pinot |
 
 ### LinkedIn
 

--- a/website/docs/administration/running_locally.md
+++ b/website/docs/administration/running_locally.md
@@ -17,14 +17,14 @@ First, let's get Pinot. You can either build it, or download it
 
 ### Build
 
-Follow these steps to checkout code from [Github](https://github.com/apache/incubator-pinot) and build Pinot locally
+Follow these steps to checkout code from [Github](https://github.com/apache/pinot) and build Pinot locally
 
 > <b>Prerequisites:</b> <br/> <p>&nbsp; Install <a href="https://maven.apache.org/install.html" target="_blank">Apache Maven</a>  3.6 or higher. </p>
 
 ```bash
 # checkout pinot
-git clone https://github.com/apache/incubator-pinot.git
-cd incubator-pinot
+git clone https://github.com/apache/pinot.git
+cd pinot
 
 # build pinot
 mvn install package -DskipTests -Pbin-dist
@@ -38,7 +38,7 @@ cd pinot-distribution/target/apache-pinot-incubating-${pinot.version}-bin/apache
 Download the latest binary release from Apache Pinot, or use this command
 
 ```bash
-wget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-${pinot.version}/apache-pinot-incubating-${pinot.version}-bin.tar.gz
+wget https://downloads.apache.org/pinot/apache-pinot-incubating-${pinot.version}/apache-pinot-incubating-${pinot.version}-bin.tar.gz
 ```
 
 Once you have the tar file,

--- a/website/docs/misc/build-docker.md
+++ b/website/docs/misc/build-docker.md
@@ -5,12 +5,12 @@ description: Build Docker Images
 draft: true
 ---
 
-The scripts to build Pinot related docker images is located at [here](https://github.com/apache/incubator-pinot/tree/master/docker/images)
+The scripts to build Pinot related docker images is located at [here](https://github.com/apache/pinot/tree/master/docker/images)
 
 You can access those scripts by running below command to checkout Pinot repo:
 
 ```bash
-git clone git@github.com:apache/incubator-pinot.git pinot
+git clone git@github.com:apache/pinot.git pinot
 cd pinot/docker/images
 ```
 
@@ -22,7 +22,7 @@ You can find current supported 3 images in this directory:
 
 ## Pinot
 
-This is a docker image of [Apache Pinot](https://github.com/apache/incubator-pinot)
+This is a docker image of [Apache Pinot](https://github.com/apache/pinot)
 
 ### How to build a docker image
 
@@ -40,7 +40,7 @@ Docker Tag: Name and tag your docker image. Default is `pinot:latest`. <br />
 Git Branch: The Pinot branch to build. Default is master. <br />
 Pinot Git URL: The Pinot Git Repo to build, users can set it to their own fork. <br />
 Please note that, the URL is `https://` based, not `git://`. <br />
-Default is the [Apache Repo: https://github.com/apache/incubator-pinot.git](https://github.com/apache/incubator-pinot.git). <br />
+Default is the [Apache Repo: https://github.com/apache/pinot.git](https://github.com/apache/pinot.git). <br />
 
 - Example of building and tagging a snapshot on your own fork:
 
@@ -51,7 +51,7 @@ Default is the [Apache Repo: https://github.com/apache/incubator-pinot.git](http
 - Example of building a release version:
 
 ```bash
-./docker-build.sh pinot:release-0.1.0 release-0.1.0 https://github.com/apache/incubator-pinot.git
+./docker-build.sh pinot:release-0.1.0 release-0.1.0 https://github.com/apache/pinot.git
 ```
 
 - Example of building current master branch as a snapshot:
@@ -83,7 +83,7 @@ docker push apachepinot/pinot:release-0.1.0
 - Example of building and publishing an image to `[apachepinot/pinot](https://hub.docker.com/u/apachepinot/repository/docker/apachepinot/pinot)` dockerHub repo.
 
 ```bash
-./docker-build-and-push.sh apachepinot/pinot:latest master https://github.com/apache/incubator-pinot.git
+./docker-build-and-push.sh apachepinot/pinot:latest master https://github.com/apache/pinot.git
 ```
 
 ## Kubernetes Examples
@@ -112,7 +112,7 @@ Docker Tag: Name and tag your docker image. Default is `pinot:latest`. <br />
 Git Branch: The Pinot branch to build. Default is master. <br />
 Pinot Git URL: The Pinot Git Repo to build, users can set it to their own fork. <br />
 Please note that, the URL is `https://` based, not `git://`. <br />
-Default is the [Apache Repo: https://github.com/apache/incubator-pinot.git](https://github.com/apache/incubator-pinot.git). <br />
+Default is the [Apache Repo: https://github.com/apache/pinot.git](https://github.com/apache/pinot.git). <br />
 
 ### How to push
 
@@ -167,7 +167,7 @@ make push
 
 ### Configuration
 
-Follow the [instructions](https://superset.incubator.apache.org/installation.html#configuration) provided by Apache Superset for writing your own superset_config.py.
+Follow the [instructions](https://superset.apache.org/installation.html#configuration) provided by Apache Superset for writing your own superset_config.py.
 
 Place this file in a local directory and mount this directory to /etc/superset inside the container. This location
 is included in the image's `PYTHONPATH`. Mounting this file to a different location is possible, but it will need to be in the PYTHONPATH.

--- a/website/docs/user-guide/query-pinot.md
+++ b/website/docs/user-guide/query-pinot.md
@@ -59,7 +59,7 @@ Query Console can be used for running ad-hoc queries (checkbox available to quer
 You can also query using the pinot-admin scripts. Make sure you follow instructions in Getting Pinot to get Pinot locally, and then
 
 ```bash
-cd incubator-pinot/pinot-tools/target/pinot-tools-pkg
+cd pinot/pinot-tools/target/pinot-tools-pkg
 bin/pinot-admin.sh PostQuery \
   -queryType sql \
   -brokerPort 8000 \

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -48,7 +48,7 @@ module.exports = {
         {to: '/blog', label: 'Blog', position: 'right'},
         // {to: 'https://docs.pinot.apache.org/community-1/blogs', label: 'Blog', position: 'right'},
         {
-          href: 'https://github.com/apache/incubator-pinot',
+          href: 'https://github.com/apache/pinot',
           label: 'GitHub',
           position: 'right',
         },
@@ -57,7 +57,7 @@ module.exports = {
     announcementBar: {
       id: 'supportus',
       content:
-        '⭐️ If you love <b>Apache Pinot</b>, please give it a star on <a target="_blank" href="https://github.com/apache/incubator-pinot"><b>GitHub</b></a>! ⭐️',
+        '⭐️ If you love <b>Apache Pinot</b>, please give it a star on <a target="_blank" href="https://github.com/apache/pinot"><b>GitHub</b></a>! ⭐️',
       backgroundColor: '#252532', // Defaults to `#fff`.
       textColor: '#fff', // Defaults to `#000`.
       isCloseable: true, // Defaults to `true`.
@@ -152,7 +152,7 @@ module.exports = {
             },
             {
               label: 'Github',
-              to: 'https://github.com/apache/incubator-pinot',
+              to: 'https://github.com/apache/pinot',
             },
             {
               label: 'Twitter',
@@ -199,7 +199,7 @@ module.exports = {
         src: 'img/logo.svg',
         href: 'https://pinot.apache.org/',
       },
-      copyright: `Disclaimer: Apache Pinot is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.<br><br>Copyright © ${new Date().getFullYear()} The Apache Software Foundation.<br>Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are registered trademarks of The Apache Software Foundation.<br><br>This page has references to third party software - Presto, PrestoDB, ThirdEye, that are not part of the Apache Software Foundation and are not covered under the Apache License.`,
+      copyright: `Copyright © ${new Date().getFullYear()} The Apache Software Foundation.<br>Apache Pinot, Pinot, Apache, the Apache feather logo, and the Apache Pinot project logo are registered trademarks of The Apache Software Foundation.<br><br>This page has references to third party software - Presto, PrestoDB, ThirdEye, that are not part of the Apache Software Foundation and are not covered under the Apache License.`,
     },
     googleAnalytics: {
       trackingID: 'UA-157446650-1',
@@ -227,7 +227,7 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          editUrl: 'https://github.com/apache/incubator-pinot/edit/master/website/',
+          editUrl: 'https://github.com/apache/pinot/edit/master/website/',
           // Sidebars filepath relative to the website dir.
           sidebarPath: require.resolve('./sidebars.js'),
         },
@@ -236,7 +236,7 @@ module.exports = {
         },
         blog: {
         path: 'blog',
-        editUrl: 'https://github.com/apache/incubator-pinot-site/edit/dev/website/',
+        editUrl: 'https://github.com/apache/pinot-site/edit/dev/website/',
         blogTitle: 'Blog - Apache Pinot: User-Facing Analytics',
         blogSidebarCount: 10,
         blogSidebarTitle: 'All our posts',

--- a/website/src/components/Changelog/index.js
+++ b/website/src/components/Changelog/index.js
@@ -44,7 +44,7 @@ function Commit({ commit, setSearchTerm }) {
                         style={{ minWidth: "65px", textAlign: "center" }}
                     >
                         <a
-                            href={`https://github.com/apache/incubator-pinot/pull/${commit.pr_number}`}
+                            href={`https://github.com/apache/pinot/pull/${commit.pr_number}`}
                             target="_blank"
                         >
                             <i className="feather icon-git-pull-request"></i>{" "}
@@ -58,7 +58,7 @@ function Commit({ commit, setSearchTerm }) {
                         style={{ minWidth: "65px", textAlign: "center" }}
                     >
                         <a
-                            href={`https://github.com/apache/incubator-pinot/commit/${commit.sha}`}
+                            href={`https://github.com/apache/pinot/commit/${commit.sha}`}
                             target="_blank"
                         >
                             <i className="feather icon-git-commit"></i>{" "}

--- a/website/src/pages/download.js
+++ b/website/src/pages/download.js
@@ -38,7 +38,7 @@ function Download() {
                             procedures
                         </a>{" "}
                         using these{" "}
-                        <a href="https://downloads.apache.org/incubator/pinot/KEYS">
+                        <a href="https://downloads.apache.org/pinot/KEYS">
                             KEYS
                         </a>{" "}
                         for any Apache release.
@@ -51,7 +51,7 @@ function Download() {
                         <div className="row">
                             <div className="col">
                                 <a
-                                    href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz"
+                                    href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz"
                                     className="panel panel--link text--center"
                                 >
                                     <div className="panel--icon">
@@ -60,33 +60,33 @@ function Download() {
 
                                     <div className="panel--title">0.7.1</div>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz">
                                         <div className="panel--title">
                                             Official source release
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz.sha512">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz.asc">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-src.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC
                                         </div>
                                     </a>
 
-                                    <a href="https://www.apache.org/dyn/closer.lua/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz">
                                         <div className="panel--title">
                                             Binary download
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz.sha512">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz.sha512">
                                         <div className="panel--subtitle">
                                             SHA512
                                         </div>
                                     </a>
-                                    <a href="https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz.asc">
+                                    <a href="https://downloads.apache.org/pinot/apache-pinot-incubating-0.7.1/apache-pinot-incubating-0.7.1-bin.tar.gz.asc">
                                         <div className="panel--subtitle">
                                             ASC{" "}
                                         </div>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -332,17 +332,17 @@ function Installation() {
                 >
                     <TabItem value="helm">
                         <CodeBlock className="language-bash">
-                            {`helm repo add pinot https://raw.githubusercontent.com/apache/incubator-pinot/master/kubernetes/helm\nkubectl create ns pinot\nhelm install pinot pinot/pinot -n pinot --set cluster.name=pinot`}
+                            {`helm repo add pinot https://raw.githubusercontent.com/apache/pinot/master/kubernetes/helm\nkubectl create ns pinot\nhelm install pinot pinot/pinot -n pinot --set cluster.name=pinot`}
                         </CodeBlock>
                     </TabItem>
                     <TabItem value="binary">
                         <CodeBlock className="language-bash">
-                            {`VERSION=0.7.1\nwget https://downloads.apache.org/incubator/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`}
+                            {`VERSION=0.7.1\nwget https://downloads.apache.org/pinot/apache-pinot-incubating-$VERSION/apache-pinot-incubating-$VERSION-bin.tar.gz\ntar vxf apache-pinot-incubating-*-bin.tar.gz\ncd apache-pinot-incubating-*-bin\nbin/quick-start-batch.sh`}
                         </CodeBlock>
                     </TabItem>
                     <TabItem value="github">
                         <CodeBlock className="language-bash">
-                            {`# Clone a repo\ngit clone https://github.com/apache/incubator-pinot.git\ncd incubator-pinot\n\n# Build Pinot\nmvn clean install -DskipTests -Pbin-dist\n\n# Run the Quick Demo\ncd pinot-distribution/target/apache-pinot-incubating-*-SNAPSHOT-bin/apache-pinot-incubating-*-SNAPSHOT-bin\nbin/quick-start-batch.sh`}
+                            {`# Clone a repo\ngit clone https://github.com/apache/pinot.git\ncd pinot\n\n# Build Pinot\nmvn clean install -DskipTests -Pbin-dist\n\n# Run the Quick Demo\ncd pinot-distribution/target/apache-pinot-incubating-*-SNAPSHOT-bin/apache-pinot-incubating-*-SNAPSHOT-bin\nbin/quick-start-batch.sh`}
                         </CodeBlock>
                     </TabItem>
                 </Tabs>


### PR DESCRIPTION
We still have some directory references left over on incubating, will update until the next release.