### PR TITLE
fixed broken link in footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -147,7 +147,7 @@ module.exports = {
             },
             {
               label: 'Administration',
-              to: 'https://docs.pinot.apache.org/operating-pinot',
+              to: 'https://docs.pinot.apache.org/operators/operating-pinot',
             },
           ],
         },


### PR DESCRIPTION
I was looking at the site and decided to check all the docs links. Found a URL that was missing a section.