### PR TITLE
Improve homepage component responsiveness on smaller screens

### DIFF
--- a/components/AnnouncementBar.tsx
+++ b/components/AnnouncementBar.tsx
@@ -42,19 +42,19 @@ export default function AnnouncementBar({
     }
 
     return (
-        <div className={clsx('z-50', backgroundColor, className)}>
+        <div className={clsx('z-50 w-full', backgroundColor, className)}>
             <div
                 className={clsx(
-                    'flex items-center justify-center gap-2 p-4 md:gap-4 md:p-2',
+                    'flex w-full items-center justify-center gap-2 p-4 md:gap-4 md:p-2',
                     className
                 )}
             >
                 <Link
                     href={buttonHref || '#'}
                     target={buttonTarget}
-                    className={`inline-flex items-center whitespace-nowrap text-base font-semibold hover:opacity-80 md:text-base ${buttonColor}`}
+                    className={`inline-flex max-w-full flex-wrap items-center justify-center text-sm font-semibold hover:opacity-80 sm:text-base ${buttonColor}`}
                 >
-                    <div className="ml-5 flex items-center text-left">
+                    <div className="ml-5 flex max-w-full items-center text-center">
                         {iconSrc && (
                             <img
                                 src={iconSrc}
@@ -62,7 +62,9 @@ export default function AnnouncementBar({
                                 className="mb-2 mr-3 h-6 w-auto md:mb-0 md:mr-6"
                             />
                         )}
-                        <span className={`text-base font-semibold md:text-lg ${textColor}`}>
+                        <span
+                            className={`text-sm font-semibold sm:text-base md:text-lg ${textColor}`}
+                        >
                             {text}
                         </span>
                     </div>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -22,7 +22,7 @@ const HeroSection = () => {
                     <Button
                         variant="default"
                         size="xl"
-                        className="rounded-lg bg-vine-100 px-8 py-3 text-xl"
+                        className="rounded-lg bg-vine-100 px-5 py-3 text-xl sm:px-8"
                     >
                         <Link href={siteMetadata.cta.getStarted} target="_blank">
                             Get Started
@@ -31,7 +31,7 @@ const HeroSection = () => {
                     <Button
                         variant="outline"
                         size="xl"
-                        className="rounded-lg border-2 border-vine-100 px-8 py-3 text-xl text-vine-100 hover:border-vine-120 hover:text-vine-120"
+                        className="rounded-lg border-2 border-vine-100 px-5 py-3 text-xl text-vine-100 hover:border-vine-120 hover:text-vine-120 sm:px-8"
                     >
                         <Link href={siteMetadata.cta.slackInvite} target="_blank">
                             Join Slack

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -68,7 +68,7 @@ const MobileNav = ({ stars }: MobileNavProps) => {
 
                     <div
                         ref={navRef}
-                        className={`fixed left-0 top-0 z-10 h-full max-h-96 w-screen transform bg-white shadow-xl duration-300 ease-in-out dark:bg-gray-950 dark:opacity-[0.98] ${
+                        className={`fixed left-0 top-0 z-10 h-full max-h-[27rem] w-screen transform bg-white shadow-xl duration-300 ease-in-out dark:bg-gray-950 dark:opacity-[0.98] ${
                             navShow ? 'translate-x-0' : 'translate-x-full'
                         }`}
                     >


### PR DESCRIPTION
## Problem
- The Announcement Bar was not fully responsive on smaller screens.
- Mobile nav height was less and the last two buttons were getting cut off.
- The hero section button padding appeared excessive on smaller screens.

## What Changed
- Improved responsiveness of the Announcement Bar for small screens.
- Fixed the height issue of mobile nav.
- Reduced the padding of hero section buttons for smaller screens.

## Screenshots
|Before|After|
|-------|------|
|<img width="486" height="68" alt="Screenshot 2026-02-10 010127" src="https://github.com/user-attachments/assets/2625d29c-794b-489c-abbc-a1a0604d229e" />|<img width="484" height="119" alt="Screenshot 2026-02-10 010132" src="https://github.com/user-attachments/assets/e68ce657-e407-4d18-94ff-11a56c658604" />|
|<img width="470" height="498" alt="Screenshot 2026-02-10 010243" src="https://github.com/user-attachments/assets/c1e91919-2e15-4f02-8433-9b1630b56773" />|<img width="468" height="429" alt="Screenshot 2026-02-10 010318" src="https://github.com/user-attachments/assets/5fbc60cf-8f8a-49a7-a8d2-a39b6995f0ae" />|
|<img width="435" height="612" alt="Screenshot 2026-02-10 010159" src="https://github.com/user-attachments/assets/2d1d7a07-d2c9-4615-b3a4-46f8e299377f" />|<img width="471" height="667" alt="Screenshot 2026-02-10 010210" src="https://github.com/user-attachments/assets/a1772521-f081-45c7-b80f-903fd4aee529" />|