### PR TITLE
Add company logo bar below hero section

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -5,6 +5,7 @@ import { CoreContent } from 'pliny/utils/contentlayer';
 import { Blog } from '@/.contentlayer/generated';
 import siteMetadata from '@/data/siteMetadata';
 import HeroSection from '@/components/HeroSection';
+import CompanyLogoBar from '@/components/CompanyLogoBar';
 import TextMediaSplitSection from '@/components/TextMediaSplitSection';
 import SectionContainer from '@/components/SectionContainer';
 import Features from '@/components/Features';
@@ -21,6 +22,7 @@ const Home: FC<HomeProps> = ({ posts }) => {
     return (
         <>
             <HeroSection />
+            <CompanyLogoBar />
             <TextMediaSplitSection
                 videoUrl={siteMetadata.video.videoUrl}
                 videoTitle={siteMetadata.video.title}

--- a/components/CompanyLogoBar.tsx
+++ b/components/CompanyLogoBar.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+import React from 'react';
+import companyLogos from '@/data/companyLogos';
+
+const CompanyLogoBar: React.FC = () => {
+    return (
+        <section className="flex flex-col px-6 py-14 md:mx-auto md:max-w-screen-outerLiveArea md:px-[6.75rem] md:py-[4rem]">
+            <div className="mx-auto w-full max-w-7xl">
+                <h3 className="mb-12 text-center text-lg font-semibold text-gray-700 dark:text-gray-300 md:text-xl">
+                    Trusted by engineering teams at leading companies
+                </h3>
+                <div className="flex flex-wrap items-center justify-center gap-8 md:gap-12">
+                    {companyLogos.map((company, index) => (
+                        <div
+                            key={index}
+                            className="flex items-center justify-center transition-opacity duration-300 hover:opacity-80"
+                        >
+                            <Image
+                                src={company.logo}
+                                alt={company.alt}
+                                width={120}
+                                height={40}
+                                className="h-auto w-auto max-w-[100px] grayscale dark:invert md:max-w-[120px]"
+                                priority={false}
+                            />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CompanyLogoBar;

--- a/data/companyLogos.ts
+++ b/data/companyLogos.ts
@@ -1,0 +1,54 @@
+const companyLogos = [
+    {
+        name: 'Stripe',
+        logo: '/static/images/companies/fintech/stripe.svg',
+        alt: 'Stripe'
+    },
+    {
+        name: 'Goldman Sachs',
+        logo: '/static/images/companies/fintech/goldman_sachs.svg',
+        alt: 'Goldman Sachs'
+    },
+    {
+        name: 'Uber',
+        logo: '/static/images/companies/food/uber.svg',
+        alt: 'Uber'
+    },
+    {
+        name: 'Slack',
+        logo: '/static/images/companies/cloud/slack.svg',
+        alt: 'Slack'
+    },
+    {
+        name: 'Expedia',
+        logo: '/static/images/companies/cloud/expedia.svg',
+        alt: 'Expedia'
+    },
+    {
+        name: 'LinkedIn',
+        logo: '/static/images/companies/media/linkedin.svg',
+        alt: 'LinkedIn'
+    },
+    {
+        name: 'Walmart',
+        logo: '/static/images/companies/retail/walmart.svg',
+        alt: 'Walmart'
+    },
+    {
+        name: 'Etsy',
+        logo: '/static/images/companies/retail/etsy.svg',
+        alt: 'Etsy'
+    },
+    {
+        name: 'Roku',
+        logo: '/static/images/companies/media/roku.svg',
+        alt: 'Roku'
+    },
+    {
+        name: 'Broadcom',
+        logo: '/static/images/companies/other/broadcom.svg',
+        alt: 'Broadcom'
+    }
+];
+
+export default companyLogos;


### PR DESCRIPTION
## Summary
- New `CompanyLogoBar` component showing 10 well-known Pinot adopter logos (Stripe, Goldman Sachs, Uber, Slack, Expedia, LinkedIn, Walmart, Etsy, Roku, Broadcom)
- Positioned directly below the hero for immediate social proof
- Uses existing company SVG logos from `public/static/images/companies/`
- Responsive layout with grayscale styling

## What changed for readers
Evaluators now see recognizable company logos immediately below the hero — the most effective form of social proof. Matches patterns used by ClickHouse and StarRocks.

## Files changed
- `components/CompanyLogoBar.tsx` (new)
- `data/companyLogos.ts` (new)
- `app/Main.tsx` (added CompanyLogoBar after HeroSection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)