### PR TITLE
Rename Powered By to Who Uses Pinot

### DIFF
--- a/app/powered-by/page.tsx
+++ b/app/powered-by/page.tsx
@@ -8,7 +8,7 @@ import { genPageMetadata } from '../seo';
 import siteMetadata from '@/data/siteMetadata';
 
 export const metadata = genPageMetadata({
-    title: 'Powered By',
+    title: 'Who Uses Pinot',
     description: 'Companies using Apache Pinot'
 });
 
@@ -17,7 +17,7 @@ const PoweredBy = () => {
         <section>
             <header className="p-8 pb-6 text-center md:p-0 md:pt-16">
                 <h1 className="mb-6 text-3xl font-bold md:pb-10 md:text-5xl">
-                    Powered by Apache Pinot&trade;
+                    Who Uses Apache Pinot&trade;
                 </h1>
                 <h3 className="pt-4 text-2xl font-semibold md:pb-10">Company Stories</h3>
             </header>

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -2,7 +2,7 @@ const headerNavLinks = [
     { href: '/', title: 'Home' },
     { href: 'https://docs.pinot.apache.org', title: 'Docs' },
     { href: '/download/', title: 'Download' },
-    { href: '/powered-by/', title: 'Powered by' },
+    { href: '/powered-by/', title: 'Who Uses Pinot' },
     { href: '/blog/', title: 'Blog' },
     { href: '/#join-community', title: 'Community' }
 ];


### PR DESCRIPTION
## Summary
- Navigation link: "Powered by" → "Who Uses Pinot"
- Page heading: "Powered by Apache Pinot™" → "Who Uses Apache Pinot™"
- Page metadata title updated accordingly
- URL path `/powered-by/` kept unchanged to avoid breaking external links

## What changed for readers
"Who Uses Pinot" is more intuitive for evaluators than the Apache convention "Powered by". The URL stays the same so no links break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)