### PR TITLE
Add Performance / Benchmarks section to homepage

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -11,6 +11,7 @@ import SectionContainer from '@/components/SectionContainer';
 import Features from '@/components/Features';
 import ArchitectureSection from '@/components/ArchitectureSection';
 import CompanyStories from '@/components/CompanyCarousel';
+import BenchmarkSection from '@/components/BenchmarkSection';
 import CommunitySection from '@/components/CommunitySection';
 import TextCodeSplitSection from '@/components/TextCodeSplitSection';
 import BlogSection from '@/components/BlogSection';
@@ -35,6 +36,7 @@ const Home: FC<HomeProps> = ({ posts }) => {
             <Features />
             <ArchitectureSection />
             <CompanyStories />
+            <BenchmarkSection />
             <CommunitySection />
             <TextCodeSplitSection title={siteMetadata.codeSection.header} />
             <BlogSection posts={posts} />

--- a/components/BenchmarkSection.tsx
+++ b/components/BenchmarkSection.tsx
@@ -1,0 +1,46 @@
+import benchmarkData from '@/data/benchmarkData';
+
+const BenchmarkSection: React.FC = () => {
+    return (
+        <section className="px-6 py-14 md:mx-auto md:max-w-screen-outerLiveArea md:px-[6.75rem] md:py-[6.5rem]">
+            <div className="mx-auto max-w-7xl">
+                <div className="mb-12 text-center">
+                    <h2 className="text-[1.75rem] font-bold md:text-[2.25rem] lg:text-[2.5rem]">
+                        Built for Performance
+                    </h2>
+                    <p className="mt-4 text-lg text-gray-600 dark:text-gray-400 md:text-xl">
+                        Production-proven at the world's largest internet companies
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 md:gap-8">
+                    {benchmarkData.map((metric, index) => (
+                        <div
+                            key={index}
+                            className="flex flex-col items-center rounded-lg border-2 border-amber-800 px-6 py-8 text-center transition-all hover:shadow-lg dark:border-gray-700"
+                        >
+                            <div className="text-4xl font-bold text-vine-100 md:text-5xl">
+                                {metric.value}
+                            </div>
+                            <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+                                {metric.label}
+                            </h3>
+                            <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+                                {metric.description}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="mt-12 rounded-lg bg-gray-50 px-6 py-6 text-center dark:bg-gray-900">
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                        Based on production deployments at LinkedIn, Stripe, Uber, and other Pinot users.
+                        Your results will vary based on hardware, schema design, and query complexity.
+                    </p>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default BenchmarkSection;

--- a/data/benchmarkData.ts
+++ b/data/benchmarkData.ts
@@ -1,0 +1,30 @@
+interface BenchmarkMetric {
+    value: string;
+    label: string;
+    description: string;
+}
+
+const benchmarkData: BenchmarkMetric[] = [
+    {
+        value: 'P99 < 100ms',
+        label: 'Query Latency',
+        description: 'Sub-100ms latencies for analytical queries at scale'
+    },
+    {
+        value: '200,000+ QPS',
+        label: 'Throughput',
+        description: 'Queries per second in production deployments'
+    },
+    {
+        value: '< 1 second',
+        label: 'Data Freshness',
+        description: 'End-to-end latency from Kafka to queryable'
+    },
+    {
+        value: '1M+ events/sec',
+        label: 'Ingest Rate',
+        description: 'Data ingestion throughput per second'
+    }
+];
+
+export default benchmarkData;


### PR DESCRIPTION
## Summary
- New `BenchmarkSection` component with 4 production-proven metrics:
  - **P99 < 100ms** query latency
  - **200,000+ QPS** throughput
  - **< 1 second** data freshness (Kafka to queryable)
  - **1M+ events/sec** ingestion rate
- Responsive grid (1 col mobile, 2 tablet, 4 desktop)
- Includes disclaimer about results varying by deployment
- Placed after CompanyStories and before CommunitySection
- Pure Tailwind CSS, no external charting libraries

## What changed for readers
Evaluators now see concrete performance numbers on the homepage — previously there were none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)