### PR TITLE
Add concrete company examples to use case cards

### DIFF
--- a/components/UseCase.tsx
+++ b/components/UseCase.tsx
@@ -4,7 +4,7 @@ import { UseCase as UseCaseType } from '@/data/useCasesData';
 
 interface UseCaseProps extends UseCaseType {}
 
-const UseCase: React.FC<UseCaseProps> = ({ icon, title, description, details, learnMoreLink }) => {
+const UseCase: React.FC<UseCaseProps> = ({ icon, title, description, details, example, learnMoreLink }) => {
     return (
         <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md">
             <div className="bg-vine-50 mb-4 flex h-16 w-16 items-center justify-center rounded-md">
@@ -20,6 +20,14 @@ const UseCase: React.FC<UseCaseProps> = ({ icon, title, description, details, le
                     </li>
                 ))}
             </ul>
+            {example && (
+                <div className="mb-6 rounded-md border border-amber-200 bg-amber-50 p-4">
+                    <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-amber-800">
+                        In Production at {example.company}
+                    </p>
+                    <p className="text-sm text-gray-700">{example.description}</p>
+                </div>
+            )}
             <Link
                 href={learnMoreLink}
                 className="hover:text-vine-200 inline-flex text-base font-semibold text-vine-100 transition-colors"

--- a/data/useCasesData.ts
+++ b/data/useCasesData.ts
@@ -1,9 +1,16 @@
+export interface UseCaseExample {
+    company: string;
+    description: string;
+    link: string;
+}
+
 export interface UseCase {
     id: string;
     icon: string;
     title: string;
     description: string;
     details: string[];
+    example: UseCaseExample;
     learnMoreLink: string;
 }
 
@@ -19,7 +26,14 @@ const useCasesData: UseCase[] = [
             'Fresh data ingested in real-time from streaming sources',
             'Support for complex aggregations and filters'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/getting-started'
+        example: {
+            company: 'Stripe',
+            description:
+                'Stripe uses Pinot to power real-time billing dashboards, serving 10K+ queries/sec with sub-second latency while tracking $18.6B in transactions during Black Friday-Cyber Monday.',
+            link: 'https://startree.ai/user-stories/stripe-journey-to-18-b-of-transactions-with-apache-pinot/'
+        },
+        learnMoreLink:
+            'https://startree.ai/user-stories/stripe-journey-to-18-b-of-transactions-with-apache-pinot/'
     },
     {
         id: 'user-facing-analytics',
@@ -32,7 +46,14 @@ const useCasesData: UseCase[] = [
             'Horizontally scalable architecture for growing demand',
             'Built-in multitenancy for product isolation'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/architecture'
+        example: {
+            company: 'LinkedIn',
+            description:
+                'LinkedIn built Pinot to power "Who Viewed Your Profile" and 50+ other user-facing apps, serving 250K+ queries/sec across 700M+ members.',
+            link: 'https://engineering.linkedin.com/analytics/real-time-analytics-massive-scale-pinot'
+        },
+        learnMoreLink:
+            'https://engineering.linkedin.com/analytics/real-time-analytics-massive-scale-pinot'
     },
     {
         id: 'anomaly-detection',
@@ -45,7 +66,14 @@ const useCasesData: UseCase[] = [
             'Query freshly ingested data immediately for anomaly detection',
             'High-concurrency support for continuous monitoring systems'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/data-ingestion'
+        example: {
+            company: 'Cisco Webex',
+            description:
+                'Webex processes 100+ TB of telemetry data daily through Pinot for real-time observability and anomaly detection, replacing Elasticsearch and eliminating 500+ nodes.',
+            link: 'https://startree.ai/resources/full-meetup-uber-webex-beaconstac-startree'
+        },
+        learnMoreLink:
+            'https://startree.ai/resources/full-meetup-uber-webex-beaconstac-startree'
     },
     {
         id: 'adhoc-olap',
@@ -58,7 +86,13 @@ const useCasesData: UseCase[] = [
             'SQL interface for flexible analytical queries',
             'Rich indexing options for optimized query performance'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/indexing'
+        example: {
+            company: 'Uber',
+            description:
+                'Uber runs 100+ offline analytics use cases with 500+ production tables in Pinot, serving sub-second queries for inventory, catalog, and business intelligence workloads.',
+            link: 'https://www.uber.com/blog/pinot-for-low-latency/'
+        },
+        learnMoreLink: 'https://www.uber.com/blog/pinot-for-low-latency/'
     },
     {
         id: 'event-analytics',
@@ -71,7 +105,14 @@ const useCasesData: UseCase[] = [
             'Efficient storage and querying of high-volume events',
             'Support for time-series analysis and windowing'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/getting-started'
+        example: {
+            company: 'DoorDash',
+            description:
+                'DoorDash tracks ad impressions, clicks, and orders across 500+ dimensions in real time using Pinot, reducing query latency from 30-second timeouts to under 100ms.',
+            link: 'https://startree.ai/resources/doordash-supporting-multiple-pinot-use-cases-at-scale/'
+        },
+        learnMoreLink:
+            'https://startree.ai/resources/doordash-supporting-multiple-pinot-use-cases-at-scale/'
     },
     {
         id: 'personalization',
@@ -84,7 +125,14 @@ const useCasesData: UseCase[] = [
             'Support for complex joins between user and behavioral data',
             'Upserts for real-time profile updates'
         ],
-        learnMoreLink: 'https://docs.pinot.apache.org/basics/getting-started'
+        example: {
+            company: 'LinkedIn',
+            description:
+                'LinkedIn uses Pinot to compute near-real-time features for feed personalization, retrieving member actions with attributes in under 50ms at 20,000+ queries/sec.',
+            link: 'https://startree.ai/resources/how-apache-pinot-serves-up-real-time-personalization-at-scale'
+        },
+        learnMoreLink:
+            'https://startree.ai/resources/how-apache-pinot-serves-up-real-time-personalization-at-scale'
     }
 ];
 


### PR DESCRIPTION
## Summary
- Each use case card now features a real production example with company name, one-line description, and link to a case study or blog
- "Learn More" links updated from generic docs pages to relevant case studies and engineering blogs
- New amber-highlighted "In Production at {Company}" section appears on each card

## Use case examples added

| Use Case | Company | Source |
|----------|---------|--------|
| Real-Time Dashboards | Stripe | StarTree case study (BFCM $18.6B) |
| User-Facing Analytics | LinkedIn | LinkedIn Engineering blog |
| Anomaly Detection | Cisco Webex | StarTree meetup recording |
| Ad-Hoc OLAP Queries | Uber | Uber Engineering blog |
| Event Analytics | DoorDash | StarTree case study |
| Personalization | LinkedIn | StarTree resource |

## Changes
- `data/useCasesData.ts` — Added `UseCaseExample` interface with `company`, `description`, `link` fields; populated for all 6 use cases
- `components/UseCase.tsx` — Renders the example in an amber-highlighted box above the Learn More link

## Test plan
- [ ] Verify all 6 use case cards render the company example section
- [ ] Verify all Learn More and example links are clickable and resolve
- [ ] Confirm no ESLint or build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)