### PR TITLE
Fix SEO: disable directory listings and add canonical URLs

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -44,9 +44,14 @@ export async function generateMetadata({
         };
     });
 
+    const canonicalUrl = post.canonicalUrl || `${siteMetadata.siteUrl}/${post.path}`;
+
     return {
         title: post.title,
         description: post.summary,
+        alternates: {
+            canonical: canonicalUrl
+        },
         openGraph: {
             title: post.title,
             description: post.summary,
@@ -55,7 +60,7 @@ export async function generateMetadata({
             type: 'article',
             publishedTime: publishedAt,
             modifiedTime: modifiedAt,
-            url: './',
+            url: canonicalUrl,
             images: ogImages,
             authors: authors.length > 0 ? authors : [siteMetadata.author]
         },

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,7 +5,41 @@ export default function robots(): MetadataRoute.Robots {
     return {
         rules: {
             userAgent: '*',
-            allow: '/'
+            allow: [
+                '/',
+                // Allow actual blog posts (4 segments: /blog/YYYY/MM/DD/title/)
+                // These are more specific than the disallow rules below, so they
+                // take precedence in compliant crawlers.
+                '/blog/2015/*/*/*/',
+                '/blog/2016/*/*/*/',
+                '/blog/2017/*/*/*/',
+                '/blog/2018/*/*/*/',
+                '/blog/2019/*/*/*/',
+                '/blog/2020/*/*/*/',
+                '/blog/2021/*/*/*/',
+                '/blog/2022/*/*/*/',
+                '/blog/2023/*/*/*/',
+                '/blog/2024/*/*/*/',
+                '/blog/2025/*/*/*/',
+                '/blog/2026/*/*/*/'
+            ],
+            disallow: [
+                // Block intermediate date-based directory listings under /blog/
+                // (year, year/month, year/month/day directories without a post title).
+                // The more-specific Allow rules above re-enable actual blog post URLs.
+                '/blog/2015/',
+                '/blog/2016/',
+                '/blog/2017/',
+                '/blog/2018/',
+                '/blog/2019/',
+                '/blog/2020/',
+                '/blog/2021/',
+                '/blog/2022/',
+                '/blog/2023/',
+                '/blog/2024/',
+                '/blog/2025/',
+                '/blog/2026/'
+            ]
         },
         sitemap: `${siteMetadata.siteUrl}/sitemap.xml`,
         host: siteMetadata.siteUrl

--- a/scripts/generate-directory-indexes.mjs
+++ b/scripts/generate-directory-indexes.mjs
@@ -1,0 +1,75 @@
+/**
+ * Generates noindex + redirect index.html files for intermediate date directories
+ * under the blog output path.
+ *
+ * With `output: 'export'` and `trailingSlash: true`, Next.js creates nested
+ * directories like out/blog/2025/02/17/post-title/index.html but leaves the
+ * intermediate directories (2025/, 2025/02/, 2025/02/17/) without index files.
+ * If the web server has directory indexing enabled, those paths expose raw
+ * filesystem listings that get crawled and indexed — creating duplicate,
+ * low-value pages in search results.
+ *
+ * This script walks the blog output tree and creates index.html in any
+ * directory that lacks one, containing:
+ *   - <meta name="robots" content="noindex, nofollow">
+ *   - <link rel="canonical" href="/blog/">
+ *   - <meta http-equiv="refresh"> redirect to /blog/
+ */
+
+import { readdirSync, statSync, existsSync, writeFileSync } from 'fs';
+import path from 'path';
+import siteMetadata from '../data/siteMetadata.js';
+
+const siteUrl = siteMetadata.siteUrl;
+
+function generateRedirectHtml(redirectUrl, canonicalUrl) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="robots" content="noindex, nofollow">
+<link rel="canonical" href="${canonicalUrl}">
+<meta http-equiv="refresh" content="0; url=${redirectUrl}">
+<title>Redirecting to Blog Archive</title>
+</head>
+<body>
+<p>Redirecting to the <a href="${redirectUrl}">blog archive</a>…</p>
+</body>
+</html>`;
+}
+
+function walkAndFillIndexes(dir) {
+    let created = 0;
+    const entries = readdirSync(dir);
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry);
+        if (!statSync(fullPath).isDirectory()) continue;
+
+        // Recurse into subdirectories first
+        created += walkAndFillIndexes(fullPath);
+
+        // If this directory has no index.html, create one
+        const indexPath = path.join(fullPath, 'index.html');
+        if (!existsSync(indexPath)) {
+            const redirectUrl = '/blog/';
+            const canonicalUrl = `${siteUrl}/blog/`;
+            writeFileSync(indexPath, generateRedirectHtml(redirectUrl, canonicalUrl));
+            created++;
+        }
+    }
+
+    return created;
+}
+
+export default function generateDirectoryIndexes() {
+    const outBlogDir = path.join(process.cwd(), 'out', 'blog');
+
+    if (!existsSync(outBlogDir)) {
+        console.log('No out/blog directory found — skipping directory index generation.');
+        return;
+    }
+
+    const created = walkAndFillIndexes(outBlogDir);
+    console.log(`Generated ${created} noindex redirect page(s) for intermediate blog directories.`);
+}

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,7 +1,9 @@
 import rss from './rss.mjs';
+import generateDirectoryIndexes from './generate-directory-indexes.mjs';
 
 async function postbuild() {
     await rss();
+    generateDirectoryIndexes();
 }
 
 postbuild();


### PR DESCRIPTION
## Summary
- **Postbuild script** generates `noindex` + redirect `index.html` for intermediate blog date directories (`/blog/YYYY/`, `/blog/YYYY/MM/`, `/blog/YYYY/MM/DD/`) that were exposing raw filesystem listings to crawlers
- **robots.txt** updated with `Disallow` rules for date-only directory paths, paired with more-specific `Allow` rules that preserve indexing of actual blog post URLs (`/blog/YYYY/MM/DD/title/`)
- **Blog post metadata** now includes explicit `<link rel="canonical">` using the frontmatter `canonicalUrl` field (if set) or the computed absolute URL, replacing the relative `./` OpenGraph URL

## Test plan
- [ ] Run `npm run build` and verify `out/blog/2025/index.html` contains `noindex` meta tag and redirect
- [ ] Verify `out/blog/2025/02/17/Announcing-Apache-Pinot-1-3/index.html` is unchanged (actual post)
- [ ] Check `out/robots.txt` has both Allow and Disallow rules for year prefixes
- [ ] Confirm blog post pages have `<link rel="canonical" href="https://pinot.apache.org/blog/...">` in HTML head

🤖 Generated with [Claude Code](https://claude.com/claude-code)