### PR TITLE
Use multi-arch Docker tags and Scarf gateway for all images

### DIFF
--- a/components/DownloadInstall.tsx
+++ b/components/DownloadInstall.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import pinotMeta from '@/data/pinot-meta.json';
 
 type Tab = 'docker' | 'k8s';
-type Arch = 'x86' | 'ARM64';
 
 const CopyButton: React.FC<{ text: string }> = ({ text }) => {
     const [copied, setCopied] = useState(false);
@@ -43,31 +42,17 @@ const CodeBlock: React.FC<{ lines: string[] }> = ({ lines }) => {
 
 const version = pinotMeta.latestVersion;
 
-const dockerCommands: Record<Arch, string[]> = {
-    x86: [
-        `# Pull and run Apache Pinot ${version}`,
-        `docker run -p 2123:2123 -p 9000:9000 -p 8000:8000 \\`,
-        `  apachepinot.docker.scarf.sh/apachepinot/pinot:${version} \\`,
-        `  QuickStart -type hybrid`
-    ],
-    ARM64: [
-        `# Pull and run Apache Pinot ${version} (ARM64)`,
-        `docker run -p 2123:2123 -p 9000:9000 -p 8000:8000 \\`,
-        `  apachepinot.docker.scarf.sh/apachepinot/pinot:${version}-arm64 \\`,
-        `  QuickStart -type hybrid`
-    ]
-};
+const dockerCommands = [
+    `# Pull and run Apache Pinot ${version}`,
+    `docker run -p 2123:2123 -p 9000:9000 -p 8000:8000 \\`,
+    `  apachepinot.docker.scarf.sh/apachepinot/pinot:${version} \\`,
+    `  QuickStart -type hybrid`
+];
 
-const nightlyCommands: Record<Arch, string[]> = {
-    x86: [
-        `# Pull the latest nightly build`,
-        `docker pull apachepinot.docker.scarf.sh/apachepinot/pinot:latest`
-    ],
-    ARM64: [
-        `# Pull the latest nightly build (ARM64)`,
-        `docker pull apachepinot.docker.scarf.sh/apachepinot/pinot:latest-arm64`
-    ]
-};
+const nightlyCommands = [
+    `# Pull the latest nightly build`,
+    `docker pull apachepinot.docker.scarf.sh/apachepinot/pinot:latest`
+];
 
 const k8sCommands = [
     `# Add the Pinot Helm repository`,
@@ -81,7 +66,6 @@ const k8sCommands = [
 
 const DownloadInstall: React.FC = () => {
     const [activeTab, setActiveTab] = useState<Tab>('docker');
-    const [arch, setArch] = useState<Arch>('x86');
 
     return (
         <section className="mx-auto max-w-5xl px-4 py-10 md:px-8 md:py-16">
@@ -114,28 +98,12 @@ const DownloadInstall: React.FC = () => {
 
             {activeTab === 'docker' && (
                 <div>
-                    {/* Arch toggle */}
-                    <div className="mb-4 flex space-x-2">
-                        {(['x86', 'ARM64'] as const).map((a) => (
-                            <button
-                                key={a}
-                                className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
-                                    arch === a
-                                        ? 'bg-vine-100 text-white'
-                                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                                }`}
-                                onClick={() => setArch(a)}
-                            >
-                                {a}
-                            </button>
-                        ))}
-                    </div>
-
                     {/* Stable release */}
                     <h3 className="mb-3 text-lg font-semibold">Stable Release ({version})</h3>
-                    <CodeBlock lines={dockerCommands[arch]} />
+                    <CodeBlock lines={dockerCommands} />
                     <p className="mt-3 text-sm text-gray-500">
-                        This starts a standalone Pinot cluster with the controller UI at{' '}
+                        Multi-arch image — works on both x86 and ARM64. This starts a standalone
+                        Pinot cluster with the controller UI at{' '}
                         <code className="rounded bg-gray-100 px-1 py-0.5 text-xs">
                             http://localhost:9000
                         </code>
@@ -149,7 +117,7 @@ const DownloadInstall: React.FC = () => {
                         tag points to the most recent nightly build from the main branch. Use it to
                         test unreleased features — not recommended for production.
                     </p>
-                    <CodeBlock lines={nightlyCommands[arch]} />
+                    <CodeBlock lines={nightlyCommands} />
                 </div>
             )}
 

--- a/components/DownloadInstall.tsx
+++ b/components/DownloadInstall.tsx
@@ -59,8 +59,14 @@ const dockerCommands: Record<Arch, string[]> = {
 };
 
 const nightlyCommands: Record<Arch, string[]> = {
-    x86: [`# Pull the latest nightly build`, `docker pull apachepinot/pinot:latest`],
-    ARM64: [`# Pull the latest nightly build (ARM64)`, `docker pull apachepinot/pinot:latest-arm64`]
+    x86: [
+        `# Pull the latest nightly build`,
+        `docker pull apachepinot.docker.scarf.sh/apachepinot/pinot:latest`
+    ],
+    ARM64: [
+        `# Pull the latest nightly build (ARM64)`,
+        `docker pull apachepinot.docker.scarf.sh/apachepinot/pinot:latest-arm64`
+    ]
 };
 
 const k8sCommands = [

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -3,27 +3,19 @@ import React, { FC, useState } from 'react';
 import { Button } from './ui/button';
 
 const Terminal: FC = () => {
-    const [activeTab, setActiveTab] = useState<'x86' | 'ARM64'>('x86');
     const [copied, setCopied] = useState(false);
 
-    const commands = {
-        x86: [
-            'docker run -p 9000:9000 \\',
-            'apachepinot.docker.scarf.sh/apachepinot/pinot:1.4.0 \\',
-            'QuickStart -type hybrid'
-        ],
-        ARM64: [
-            'docker run -p 9000:9000 \\',
-            'apachepinot.docker.scarf.sh/apachepinot/pinot:1.4.0-arm64 \\',
-            'QuickStart -type hybrid'
-        ]
-    };
+    const commands = [
+        'docker run -p 9000:9000 \\',
+        'apachepinot.docker.scarf.sh/apachepinot/pinot:1.4.0 \\',
+        'QuickStart -type hybrid'
+    ];
 
     const handleCopy = async () => {
         try {
-            await navigator.clipboard.writeText(commands[activeTab].join('\n'));
+            await navigator.clipboard.writeText(commands.join('\n'));
             setCopied(true);
-            setTimeout(() => setCopied(false), 2000); // Show copied status for 2 seconds
+            setTimeout(() => setCopied(false), 2000);
         } catch (err) {
             console.error('Failed to copy text: ', err);
         }
@@ -49,25 +41,8 @@ const Terminal: FC = () => {
                         <div className="h-3 w-3 rounded-full bg-green-500"></div>
                     </div>
                 </div>
-                {/* Tab buttons */}
-                <div className="mb-2 ml-8 flex space-x-1 border-b-2">
-                    {(['x86', 'ARM64'] as const).map((arch) => (
-                        <button
-                            key={arch}
-                            className={`border-b-4 px-4 py-2 pt-5 font-[Source_Code_Pro]
-                            ${
-                                activeTab === arch
-                                    ? 'border-rose-700 text-base font-semibold'
-                                    : 'border-transparent opacity-30'
-                            }`}
-                            onClick={() => setActiveTab(arch)}
-                        >
-                            {arch}
-                        </button>
-                    ))}
-                </div>
-                <div className="table w-full whitespace-pre-wrap p-4 font-[Source_Code_Pro] leading-loose">
-                    {renderCommandWithNumbers(commands[activeTab])}
+                <div className="table w-full whitespace-pre-wrap p-4 pt-6 font-[Source_Code_Pro] leading-loose">
+                    {renderCommandWithNumbers(commands)}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- **Multi-arch manifests**: Removes the x86/ARM64 architecture toggle from both `DownloadInstall` (download page) and `Terminal` (homepage). Pinot publishes multi-arch Docker manifests, so a single tag (e.g., `:1.4.0`, `:latest`) works on both architectures.
- **Scarf gateway**: Fixes nightly Docker commands to pull from `apachepinot.docker.scarf.sh/apachepinot/pinot:latest` instead of bare `apachepinot/pinot:latest`, so all Docker pulls are tracked consistently.

### Files changed
- `components/DownloadInstall.tsx` — removed `Arch` type, arch toggle UI, per-arch command maps; single command set with "Multi-arch image" note
- `components/Terminal.tsx` — removed x86/ARM64 tab switcher; single command block

## Test plan
- [x] `yarn build` — builds successfully
- [ ] Visual review: download page no longer shows x86/ARM64 toggle
- [ ] Visual review: homepage terminal no longer shows x86/ARM64 tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)