### PR TITLE
Add dedicated community page

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,0 +1,16 @@
+import CommunityPage from '@/components/CommunityPage';
+import { genPageMetadata } from '../seo';
+
+export const metadata = genPageMetadata({
+    title: 'Community',
+    description:
+        'Join the Apache Pinot community — connect on Slack, contribute on GitHub, attend meetups, and subscribe to mailing lists'
+});
+
+export default function Page() {
+    return (
+        <section>
+            <CommunityPage />
+        </section>
+    );
+}

--- a/components/CommunityPage.tsx
+++ b/components/CommunityPage.tsx
@@ -1,0 +1,155 @@
+import Image from 'next/image';
+import {
+    communityChannels,
+    contributeSections,
+    mailingLists,
+    type CommunityResource,
+    type CommunitySection
+} from '@/data/communityData';
+
+const ChannelCard = ({ name, icon, link, description, isWide = false }: CommunityResource) => {
+    return (
+        <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-center rounded-lg border-2 border-amber-800 p-6 transition-colors hover:bg-gray-100 dark:border-gray-800 dark:hover:bg-gray-800"
+        >
+            <div
+                className={`${
+                    isWide ? 'w-auto' : 'w-16'
+                } relative mb-3 flex h-16 items-center justify-center`}
+            >
+                <Image
+                    src={icon}
+                    alt={`${name} icon`}
+                    width={isWide ? 120 : 44}
+                    height={44}
+                    style={{ width: 'auto', height: 'auto' }}
+                />
+            </div>
+            <h3 className="mb-1 text-lg font-semibold">{name}</h3>
+            <p className="text-center text-sm text-gray-600 dark:text-gray-400">{description}</p>
+        </a>
+    );
+};
+
+const ContributeSection = ({ title, description, resources }: CommunitySection) => {
+    return (
+        <div className="rounded-lg border border-gray-200 p-6 dark:border-gray-700">
+            <h3 className="mb-2 text-xl font-semibold">{title}</h3>
+            <p className="mb-4 text-gray-600 dark:text-gray-400">{description}</p>
+            <ul className="space-y-3">
+                {resources.map((resource) => (
+                    <li key={resource.label}>
+                        <a
+                            href={resource.href}
+                            target={resource.external ? '_blank' : undefined}
+                            rel={resource.external ? 'noopener noreferrer' : undefined}
+                            className="group flex items-start"
+                        >
+                            <span className="mr-2 text-amber-700">&#8594;</span>
+                            <span>
+                                <span className="font-medium text-amber-800 group-hover:underline dark:text-amber-500">
+                                    {resource.label}
+                                </span>
+                                <span className="ml-1 text-sm text-gray-500 dark:text-gray-400">
+                                    &mdash; {resource.description}
+                                </span>
+                            </span>
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+const CommunityPage = () => {
+    return (
+        <div className="mx-auto max-w-5xl px-6 py-14 md:py-20">
+            {/* Hero */}
+            <div className="mb-16 text-center">
+                <h1 className="mb-4 text-4xl font-bold md:text-5xl">Community</h1>
+                <p className="mx-auto max-w-2xl text-lg text-gray-600 dark:text-gray-400">
+                    Apache Pinot is built by a vibrant open-source community. Whether you&apos;re a
+                    user, contributor, or just curious &mdash; there are many ways to get involved.
+                </p>
+            </div>
+
+            {/* Connect */}
+            <section className="mb-16">
+                <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">Connect with Us</h2>
+                <div className="grid grid-cols-2 gap-6 md:grid-cols-3">
+                    {communityChannels.map((channel) => (
+                        <ChannelCard key={channel.name} {...channel} />
+                    ))}
+                </div>
+            </section>
+
+            {/* Contribute */}
+            <section className="mb-16">
+                <h2 className="mb-8 text-center text-2xl font-bold md:text-3xl">Contribute</h2>
+                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {contributeSections.map((section) => (
+                        <ContributeSection key={section.title} {...section} />
+                    ))}
+                </div>
+            </section>
+
+            {/* Mailing Lists */}
+            <section className="mb-16">
+                <h2 className="mb-4 text-center text-2xl font-bold md:text-3xl">Mailing Lists</h2>
+                <p className="mb-8 text-center text-gray-600 dark:text-gray-400">
+                    Apache Pinot uses mailing lists for project communication. Subscribe to stay
+                    informed.
+                </p>
+                <div className="overflow-x-auto">
+                    <table className="w-full text-left">
+                        <thead>
+                            <tr className="border-b border-gray-200 dark:border-gray-700">
+                                <th className="px-4 py-3 font-semibold">List</th>
+                                <th className="px-4 py-3 font-semibold">Description</th>
+                                <th className="px-4 py-3 font-semibold">Subscribe</th>
+                                <th className="px-4 py-3 font-semibold">Archive</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {mailingLists.map((list) => (
+                                <tr
+                                    key={list.name}
+                                    className="border-b border-gray-100 dark:border-gray-800"
+                                >
+                                    <td className="px-4 py-3 font-medium">{list.email}</td>
+                                    <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+                                        {list.description}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <a
+                                            href={list.subscribe}
+                                            className="text-amber-800 hover:underline dark:text-amber-500"
+                                        >
+                                            Subscribe
+                                        </a>
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <a
+                                            href={list.archive}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-amber-800 hover:underline dark:text-amber-500"
+                                        >
+                                            Archive
+                                        </a>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+    );
+};
+
+export default CommunityPage;

--- a/data/blog/2025-02-17-Announcing-Apache-Pinot-1-3.mdx
+++ b/data/blog/2025-02-17-Announcing-Apache-Pinot-1-3.mdx
@@ -74,6 +74,6 @@ The full release notes are available at [https://github.com/apache/pinot/release
 
 -   [Download page](https://pinot.apache.org/download/)
 -   [Getting started](https://docs.pinot.apache.org/getting-started)
--   [Join our Slack channel](https://communityinviter.com/apps/apache-pinot/apache-pinot)
+-   [Join our Slack channel](https://inviter.co/apache-pinot)
 -   [See our upcoming events](https://www.meetup.com/apache-pinot)
 -   [Follow us on social media](https://twitter.com/ApachePinot)

--- a/data/communityData.ts
+++ b/data/communityData.ts
@@ -1,0 +1,150 @@
+export type CommunityResource = {
+    name: string;
+    icon: string;
+    link: string;
+    description: string;
+    isWide?: boolean;
+    target?: string;
+};
+
+export type CommunitySection = {
+    title: string;
+    description: string;
+    resources: {
+        label: string;
+        href: string;
+        description: string;
+        external?: boolean;
+    }[];
+};
+
+export const communityChannels: CommunityResource[] = [
+    {
+        name: 'Slack',
+        icon: '/static/images/socials/slack.svg',
+        link: 'https://join.slack.com/t/apache-pinot/shared_invite/zt-2t4m15dl2-SnVmZenainX_bq1_dY6XYg',
+        description: 'Chat with the community in real time'
+    },
+    {
+        name: 'GitHub',
+        icon: '/static/images/socials/github.svg',
+        link: 'https://github.com/apache/pinot',
+        description: 'Browse source code, report issues, and contribute'
+    },
+    {
+        name: 'Meetups',
+        icon: '/static/images/socials/meetup.svg',
+        link: 'https://www.meetup.com/apache-pinot/',
+        description: 'Join local and virtual Apache Pinot meetups'
+    },
+    {
+        name: 'RTA Summit',
+        icon: '/static/images/socials/rta.svg',
+        link: 'https://rtasummit.com',
+        description: 'Annual real-time analytics conference',
+        isWide: true
+    },
+    {
+        name: 'YouTube',
+        icon: '/static/images/socials/youtube.svg',
+        link: 'https://www.youtube.com/@Apache_Pinot',
+        description: 'Watch talks, tutorials, and deep dives',
+        isWide: true
+    },
+    {
+        name: 'Meetup in a Box',
+        icon: '/static/images/socials/miab.svg',
+        link: 'https://startree.ai/meetupinabox',
+        description: 'Everything you need to host your own Pinot meetup'
+    }
+];
+
+export const contributeSections: CommunitySection[] = [
+    {
+        title: 'Contribute Code',
+        description:
+            'Help build Apache Pinot by contributing code, fixing bugs, or adding features.',
+        resources: [
+            {
+                label: 'GitHub Repository',
+                href: 'https://github.com/apache/pinot',
+                description: 'Clone the repo and start contributing',
+                external: true
+            },
+            {
+                label: 'Good First Issues',
+                href: 'https://github.com/apache/pinot/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22',
+                description: 'Find beginner-friendly issues to get started',
+                external: true
+            },
+            {
+                label: 'Contribution Guide',
+                href: 'https://docs.pinot.apache.org/developers/developers-and-contributors',
+                description: 'Learn how to set up your dev environment and submit PRs',
+                external: true
+            }
+        ]
+    },
+    {
+        title: 'Report Issues & Request Features',
+        description:
+            'Found a bug or have an idea for improvement? Let us know through our issue tracker.',
+        resources: [
+            {
+                label: 'File an Issue',
+                href: 'https://github.com/apache/pinot/issues/new/choose',
+                description: 'Report bugs or request new features',
+                external: true
+            },
+            {
+                label: 'Open Issues',
+                href: 'https://github.com/apache/pinot/issues',
+                description: 'Browse and triage existing issues',
+                external: true
+            }
+        ]
+    },
+    {
+        title: 'Improve Documentation',
+        description:
+            'Good documentation helps everyone. Contribute improvements, fix typos, or write new guides.',
+        resources: [
+            {
+                label: 'Docs Site',
+                href: 'https://docs.pinot.apache.org',
+                description: 'Read the official Apache Pinot documentation',
+                external: true
+            },
+            {
+                label: 'Docs Repository',
+                href: 'https://github.com/pinot-contrib/pinot-docs',
+                description: 'Contribute to the documentation source',
+                external: true
+            }
+        ]
+    }
+];
+
+export const mailingLists = [
+    {
+        name: 'Users',
+        email: 'users@pinot.apache.org',
+        subscribe: 'mailto:users-subscribe@pinot.apache.org',
+        archive: 'https://lists.apache.org/list.html?users@pinot.apache.org',
+        description: 'For questions about using Apache Pinot'
+    },
+    {
+        name: 'Dev',
+        email: 'dev@pinot.apache.org',
+        subscribe: 'mailto:dev-subscribe@pinot.apache.org',
+        archive: 'https://lists.apache.org/list.html?dev@pinot.apache.org',
+        description: 'For development discussions and proposals'
+    },
+    {
+        name: 'Commits',
+        email: 'commits@pinot.apache.org',
+        subscribe: 'mailto:commits-subscribe@pinot.apache.org',
+        archive: 'https://lists.apache.org/list.html?commits@pinot.apache.org',
+        description: 'Automated notifications for code commits'
+    }
+];

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -6,7 +6,7 @@ const headerNavLinks = [
     { href: '/download/', title: 'Download' },
     { href: '/powered-by/', title: 'Who Uses Pinot' },
     { href: '/blog/', title: 'Blog' },
-    { href: '/#join-community', title: 'Community' }
+    { href: '/community/', title: 'Community' }
 ];
 
 export default headerNavLinks;


### PR DESCRIPTION
## Summary
- Create a new `/community/` page with three sections: Connect (Slack, GitHub, Meetups, RTA Summit, YouTube, Meetup in a Box), Contribute (code, issues, docs), and Mailing Lists (users, dev, commits)
- Extract community data into a dedicated `data/communityData.ts` file
- Update nav link from `/#join-community` anchor to `/community/` route

## Test plan
- [ ] Verify `/community/` page renders correctly
- [ ] Verify nav link in header and mobile nav navigates to the new page
- [ ] Verify all external links open correctly
- [ ] Verify mailing list subscribe links work
- [ ] Verify the home page CommunitySection still renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)