### PR TITLE
Remove bottom example videos from homepage

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -14,7 +14,6 @@ import BenchmarkSection from '@/components/BenchmarkSection';
 import CommunitySection from '@/components/CommunitySection';
 import TextCodeSplitSection from '@/components/TextCodeSplitSection';
 import BlogSection from '@/components/BlogSection';
-import VideoEmbed from '@/components/VideoEmbed';
 
 interface HomeProps {
     posts: CoreContent<Blog>[];
@@ -48,15 +47,6 @@ const Home: FC<HomeProps> = ({ posts }) => {
                 imageAlt={siteMetadata.youtubeShare.imageAlt}
                 target="_self"
             />
-            {siteMetadata.youtubeShare.exampleVideos && (
-                <section className="bg-stone-100 pb-14 dark:bg-gray-900 md:pb-[6.5rem]">
-                    <div className="mx-auto grid max-w-screen-outerLiveArea grid-cols-1 gap-6 px-5 sm:px-6 md:grid-cols-2 md:px-[5.5rem]">
-                        {siteMetadata.youtubeShare.exampleVideos.map((video, index) => (
-                            <VideoEmbed key={index} src={video.url} title={video.title} />
-                        ))}
-                    </div>
-                </section>
-            )}
         </>
     );
 };


### PR DESCRIPTION
## Summary
- Remove the 2 embedded YouTube example videos from the bottom of the homepage
- Remove unused `VideoEmbed` import from Main.tsx

## Test plan
- [ ] Verify homepage loads without the video section at the bottom
- [ ] Verify the YouTube share/CTA section above still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)