### PR TITLE
Remove quickstart terminal section from homepage

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -13,7 +13,7 @@ import Features from '@/components/Features';
 import CompanyStories from '@/components/CompanyCarousel';
 import BenchmarkSection from '@/components/BenchmarkSection';
 import CommunitySection from '@/components/CommunitySection';
-import TextCodeSplitSection from '@/components/TextCodeSplitSection';
+
 import QuickstartCTA from '@/components/QuickstartCTA';
 import BlogSection from '@/components/BlogSection';
 
@@ -40,7 +40,7 @@ const Home: FC<HomeProps> = ({ posts }) => {
             <CompanyStories />
             <BenchmarkSection />
             <CommunitySection />
-            <TextCodeSplitSection title={siteMetadata.codeSection.header} />
+
             <BlogSection posts={posts} />
             <TextMediaSplitSection
                 heading={siteMetadata.youtubeShare.heading}


### PR DESCRIPTION
## Summary
- Remove the "Start Your Real-Time Analytics Journey" section with the Docker quickstart terminal from the homepage

## Test plan
- [ ] Verify homepage renders without the terminal section
- [ ] Verify no broken imports or build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)