### PR TITLE
Add 1.5.0 to the Downloads Section

### DIFF
--- a/data/downloads/1.5.0.mdx
+++ b/data/downloads/1.5.0.mdx
@@ -1,0 +1,16 @@
+---
+version: 1.5.0
+date: 04/15/2026
+href: https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz
+officialSource:
+    download: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz'
+    sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz.sha512'
+    asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz.asc'
+binary:
+    download: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz'
+    sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz.sha512'
+    asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz.asc'
+releaseNotes: 'This release delivers significant improvements across the Multi-stage Query Engine (new UNNEST support, enriched joins, aggregation rewrites), Upsert (offline table support, commit-time compaction, xxhash compression), a new Federation / Multi-Cluster Routing framework, Kafka 4.x support, real-time auto-reset, Time Series Engine enhancements, new indexing capabilities (N-gram, IFST, combined Lucene), Query Resource Isolation, and numerous performance optimizations, security hardening, and bug fixes. It includes over 1100 commits from the community.'
+---
+
+This release delivers significant improvements across the Multi-stage Query Engine (new UNNEST support, enriched joins, aggregation rewrites), Upsert (offline table support, commit-time compaction, xxhash compression), a new Federation / Multi-Cluster Routing framework, Kafka 4.x support, real-time auto-reset, Time Series Engine enhancements, new indexing capabilities (N-gram, IFST, combined Lucene), Query Resource Isolation, and numerous performance optimizations, security hardening, and bug fixes. It includes over 1100 commits from the community.


### PR DESCRIPTION
## Summary
- Adds the download entry for Apache Pinot 1.5.0 (released 2026-04-15)
- Uses Scarf gateway URLs following the established pattern

As per the doc https://github.com/apache/pinot-site/blob/new-site-dev/RELEASE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)