### PR TITLE
Update pinot-meta.json latestVersion to 1.5.0

### DIFF
--- a/data/pinot-meta.json
+++ b/data/pinot-meta.json
@@ -1,8 +1,8 @@
 {
-    "latestVersion": "1.4.0",
-    "latestReleaseDate": "2025-09-30",
-    "previousVersion": "1.3.0",
-    "previousReleaseDate": "2025-02-17",
+    "latestVersion": "1.5.0",
+    "latestReleaseDate": "2026-04-15",
+    "previousVersion": "1.4.0",
+    "previousReleaseDate": "2025-09-30",
     "tagline": "Apache Pinot is an open-source distributed OLAP database for user-facing and agent-facing real-time analytics, delivering sub-second queries on fresh data at very high concurrency.",
     "heroHeadline": "Real-Time Analytics for Users and AI Agents",
     "heroDescription": "Apache Pinot\u2122 is an open-source distributed OLAP database for user-facing and agent-facing real-time analytics. From interactive dashboards to LLM-powered decision engines, Pinot delivers sub-second queries on fresh data at petabyte scale.",
@@ -54,6 +54,6 @@
     },
     "docsUrl": "https://docs.pinot.apache.org/",
     "githubUrl": "https://github.com/apache/pinot",
-    "lastVerified": "2025-09-30",
-    "lastVerifiedVersion": "1.4.0"
+    "lastVerified": "2026-04-15",
+    "lastVerifiedVersion": "1.5.0"
 }


### PR DESCRIPTION
## Summary
- Updates `latestVersion` from 1.4.0 to 1.5.0 in `data/pinot-meta.json`
- Shifts 1.4.0 to `previousVersion`
- Updates `lastVerified` and `lastVerifiedVersion` to 1.5.0

This ensures the "Latest" badge on the download page and other version-dependent components reflect the 1.5.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)