### PR TITLE
Add Apache Pinot 1.5.1 release

### DIFF
--- a/components/QuickstartCTA.tsx
+++ b/components/QuickstartCTA.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import siteMetadata from '@/data/siteMetadata';
 
 const dockerCommand =
-    'docker run -p 9000:9000 apachepinot.docker.scarf.sh/apachepinot/pinot:1.4.0 QuickStart -type hybrid';
+    'docker run -p 9000:9000 apachepinot.docker.scarf.sh/apachepinot/pinot:1.5.1 QuickStart -type hybrid';
 
 const QuickstartCTA: React.FC = () => {
     const [copied, setCopied] = useState(false);

--- a/components/ReleaseBanner.tsx
+++ b/components/ReleaseBanner.tsx
@@ -1,10 +1,11 @@
 import siteMetadata from '@/data/siteMetadata';
+import pinotMeta from '@/data/pinot-meta.json';
 import AnnouncementBar from './AnnouncementBar';
 
 export default function ReleaseBanner() {
     return (
         <AnnouncementBar
-            text="🎉🎉🎉 Announcing the release of Apache Pinot 1.3.0"
+            text={`Announcing the release of Apache Pinot ${pinotMeta.latestVersion}`}
             backgroundColor="bg-sky-200"
             textColor="text-black"
             buttonText={siteMetadata.announcement.buttonText}

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -7,7 +7,7 @@ const Terminal: FC = () => {
 
     const commands = [
         'docker run -p 9000:9000 \\',
-        'apachepinot.docker.scarf.sh/apachepinot/pinot:1.4.0 \\',
+        'apachepinot.docker.scarf.sh/apachepinot/pinot:1.5.1 \\',
         'QuickStart -type hybrid'
     ];
 

--- a/data/downloads/1.5.1.mdx
+++ b/data/downloads/1.5.1.mdx
@@ -1,0 +1,16 @@
+---
+version: 1.5.1
+date: 06/05/2026
+href: https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz
+officialSource:
+    download: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz'
+    sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz.sha512'
+    asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz.asc'
+binary:
+    download: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz'
+    sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz.sha512'
+    asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz.asc'
+releaseNotes: 'Apache Pinot 1.5.1 is a security patch release based on 1.5.0, with dependency updates and dependency-exclusion changes to resolve reported CVEs and no functional, API, configuration, or wire-format changes.'
+---
+
+Apache Pinot 1.5.1 is a security patch release based on 1.5.0, with dependency updates and dependency-exclusion changes to resolve reported CVEs and no functional, API, configuration, or wire-format changes.

--- a/data/downloadsData.ts
+++ b/data/downloadsData.ts
@@ -17,6 +17,44 @@ type DownloadData = {
 
 const downloadData: DownloadData[] = [
     {
+        version: '1.5.1',
+        date: '6/5/2026',
+        href: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz',
+        officialSource: {
+            download:
+                'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz',
+            sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz.sha512',
+            asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-src.tar.gz.asc'
+        },
+        binary: {
+            download:
+                'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz',
+            sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz.sha512',
+            asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.1/apache-pinot-1.5.1-bin.tar.gz.asc'
+        },
+        releaseNotes:
+            'Apache Pinot 1.5.1 is a security patch release based on 1.5.0, with dependency updates and dependency-exclusion changes to resolve reported CVEs and no functional, API, configuration, or wire-format changes.'
+    },
+    {
+        version: '1.5.0',
+        date: '4/15/2026',
+        href: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz',
+        officialSource: {
+            download:
+                'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz',
+            sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz.sha512',
+            asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-src.tar.gz.asc'
+        },
+        binary: {
+            download:
+                'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz',
+            sha512: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz.sha512',
+            asc: 'https://apachepinot.gateway.scarf.sh/pinot/1.5.0/apache-pinot-1.5.0-bin.tar.gz.asc'
+        },
+        releaseNotes:
+            'This release delivers significant improvements across the Multi-stage Query Engine (new UNNEST support, enriched joins, aggregation rewrites), Upsert (offline table support, commit-time compaction, xxhash compression), a new Federation / Multi-Cluster Routing framework, Kafka 4.x support, real-time auto-reset, Time Series Engine enhancements, new indexing capabilities (N-gram, IFST, combined Lucene), Query Resource Isolation, and numerous performance optimizations, security hardening, and bug fixes. It includes over 1100 commits from the community.'
+    },
+    {
         version: '1.4.0',
         date: '9/30/2025',
         href: 'https://apachepinot.gateway.scarf.sh/pinot/1.4.0/apache-pinot-1.4.0-bin.tar.gz',

--- a/data/pinot-meta.json
+++ b/data/pinot-meta.json
@@ -1,8 +1,8 @@
 {
-    "latestVersion": "1.5.0",
-    "latestReleaseDate": "2026-04-15",
-    "previousVersion": "1.4.0",
-    "previousReleaseDate": "2025-09-30",
+    "latestVersion": "1.5.1",
+    "latestReleaseDate": "2026-06-05",
+    "previousVersion": "1.5.0",
+    "previousReleaseDate": "2026-04-15",
     "tagline": "Apache Pinot is an open-source distributed OLAP database for user-facing and agent-facing real-time analytics, delivering sub-second queries on fresh data at very high concurrency.",
     "heroHeadline": "Real-Time Analytics for Users and AI Agents",
     "heroDescription": "Apache Pinot\u2122 is an open-source distributed OLAP database for user-facing and agent-facing real-time analytics. From interactive dashboards to LLM-powered decision engines, Pinot delivers sub-second queries on fresh data at petabyte scale.",
@@ -54,6 +54,6 @@
     },
     "docsUrl": "https://docs.pinot.apache.org/",
     "githubUrl": "https://github.com/apache/pinot",
-    "lastVerified": "2026-04-15",
-    "lastVerifiedVersion": "1.5.0"
+    "lastVerified": "2026-06-05",
+    "lastVerifiedVersion": "1.5.1"
 }

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -113,10 +113,10 @@ const siteMetadata = {
         }
     },
     announcement: {
-        text: 'Feb 11 - Online Meetup: Query, Ingestion, and Apache Pinot Core:  ',
-        buttonText: 'RSVP Here',
-        link: 'https://www.meetup.com/apache-pinot/events/313131111/',
-        expiresAfter: '2026-02-12'
+        text: `Apache Pinot ${pinotMeta.latestVersion} is available now.`,
+        buttonText: 'Download Now',
+        link: '/download/',
+        expiresAfter: '2026-09-05'
     },
     youtubeShare: {
         heading: 'Share Your Knowledge on Apache Pinot YouTube channel!',


### PR DESCRIPTION
## Summary
- add Apache Pinot 1.5.1 download metadata and release-note MDX
- add the missing Apache Pinot 1.5.0 download entry so release history remains contiguous
- update the latest-release SSOT, announcement CTA, and Docker quickstart snippets to 1.5.1

## User manual
- Go to `/download/` and verify Apache Pinot 1.5.1 is marked `Latest`.
- Use the source and binary download links for 1.5.1, along with the matching SHA512 and ASC links, to verify the release artifacts.
- The homepage/download quickstart command now uses `apachepinot.docker.scarf.sh/apachepinot/pinot:1.5.1`.

## Sample table config or queries
No Pinot table config changes are required for this website update. A quick local smoke test after running the Docker quickstart is:

```sql
SELECT COUNT(*)
FROM baseballStats;
```

## Validation
- `yarn prettier --write data/pinot-meta.json data/downloads/1.5.1.mdx data/downloads/1.5.0.mdx data/downloadsData.ts components/Terminal.tsx components/QuickstartCTA.tsx components/ReleaseBanner.tsx data/siteMetadata.js`
- `yarn check:consistency`
- `yarn test`
- `yarn lint:check` (passes with existing unrelated warnings)
- `yarn build`
- local `/download` smoke check showed 1.5.1 as Latest and 1.5.0 below it
